### PR TITLE
consensus: fix upgrade with same name (#278)

### DIFF
--- a/bcs/consensus/tdpos/tdpos.go
+++ b/bcs/consensus/tdpos/tdpos.go
@@ -92,9 +92,9 @@ func NewTdposConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Co
 		contractGetTdposInfos:     tdpos.runGetTdposInfos,
 	}
 	for method, f := range tdposKMethods {
-		if _, err := cCtx.Contract.GetKernRegistry().GetKernMethod(schedule.bindContractBucket, method); err != nil {
-			cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
-		}
+		// 若有历史句柄，删除老句柄
+		cCtx.Contract.GetKernRegistry().UnregisterKernMethod(schedule.bindContractBucket, method)
+		cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
 	}
 
 	// 凡属于共识升级的逻辑，新建的Tdpos实例将直接将当前值置为true，原因是上一共识模块已经在当前值生成了高度为trigger height的区块，新的实例会再生成一边

--- a/bcs/consensus/tdpos/tdpos_test.go
+++ b/bcs/consensus/tdpos/tdpos_test.go
@@ -16,6 +16,7 @@ import (
 
 func getTdposConsensusConf() string {
 	return `{
+		"version": "2",
         "timestamp": "1559021720000000000",
         "proposer_num": "2",
         "period": "3000",
@@ -31,6 +32,7 @@ func getTdposConsensusConf() string {
 
 func getBFTTdposConsensusConf() string {
 	return `{
+		"version": "2",
         "timestamp": "1559021720000000000",
         "proposer_num": "2",
         "period": "3000",

--- a/bcs/consensus/xpoa/common.go
+++ b/bcs/consensus/xpoa/common.go
@@ -30,7 +30,7 @@ const (
 )
 
 type xpoaConfig struct {
-	Version int64 `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 	// 每个候选人每轮出块个数
 	BlockNum int64 `json:"block_num"`
 	// 单位为毫秒

--- a/bcs/consensus/xpoa/schedule.go
+++ b/bcs/consensus/xpoa/schedule.go
@@ -2,6 +2,7 @@ package xpoa
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	common "github.com/xuperchain/xupercore/kernel/consensus/base/common"
@@ -35,13 +36,18 @@ type xpoaSchedule struct {
 }
 
 func NewXpoaSchedule(xconfig *xpoaConfig, cCtx context.ConsensusCtx, startHeight int64) *xpoaSchedule {
+	version, err := strconv.ParseInt(xconfig.Version, 10, 64)
+	if err != nil {
+		cCtx.XLog.Error("Xpoa::NewXpoaSchedule::Parse version error.", "err", err)
+		return nil
+	}
 	s := xpoaSchedule{
 		address:            cCtx.Network.PeerInfo().Account,
 		period:             xconfig.Period,
 		blockNum:           xconfig.BlockNum,
 		startHeight:        startHeight,
 		consensusName:      "poa",
-		consensusVersion:   xconfig.Version,
+		consensusVersion:   version,
 		bindContractBucket: poaBucket,
 		ledger:             cCtx.Ledger,
 		log:                cCtx.XLog,

--- a/bcs/consensus/xpoa/xpoa.go
+++ b/bcs/consensus/xpoa/xpoa.go
@@ -3,6 +3,7 @@ package xpoa
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/xuperchain/xupercore/kernel/common/xcontext"
@@ -65,7 +66,11 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: xpoa struct unmarshal error", "error", err)
 		return nil
 	}
-
+	version, err := strconv.ParseInt(xconfig.Version, 10, 64)
+	if err != nil {
+		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: version error", "error", err)
+		return nil
+	}
 	// create xpoaSchedule
 	schedule := NewXpoaSchedule(xconfig, cCtx, cCfg.StartHeight)
 	if schedule == nil {
@@ -75,7 +80,7 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 	// 创建status实例
 	status := &XpoaStatus{
 		Name:        "poa",
-		Version:     xconfig.Version,
+		Version:     version,
 		StartHeight: cCfg.StartHeight,
 		Index:       cCfg.Index,
 		election:    schedule,
@@ -100,9 +105,9 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		contractGetValidates: xpoa.methodGetValidates,
 	}
 	for method, f := range xpoaKMethods {
-		if _, err := cCtx.Contract.GetKernRegistry().GetKernMethod(schedule.bindContractBucket, method); err != nil {
-			cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
-		}
+		// 若有历史句柄，删除老句柄
+		cCtx.Contract.GetKernRegistry().UnregisterKernMethod(schedule.bindContractBucket, method)
+		cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
 	}
 
 	// 凡属于共识升级的逻辑，新建的Xpoa实例将直接将当前值置为true，原因是上一共识模块已经在当前值生成了高度为trigger height的区块，新的实例会再生成一边

--- a/bcs/consensus/xpoa/xpoa_test.go
+++ b/bcs/consensus/xpoa/xpoa_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestUnmarshalConfig(t *testing.T) {
 	cStr := `{
+		"version": "2",
 		"period": 3000,
 		"block_num": 10,
 		"init_proposer": {
@@ -33,6 +34,7 @@ func TestUnmarshalConfig(t *testing.T) {
 
 func getXpoaConsensusConf() string {
 	return `{
+		"version": "2",
         "period":3000,
         "block_num":10,
         "init_proposer": {
@@ -43,6 +45,7 @@ func getXpoaConsensusConf() string {
 
 func getBFTXpoaConsensusConf() string {
 	return `{
+		"version": "2",
         "period":3000,
         "block_num":10,
         "init_proposer": {

--- a/kernel/consensus/mock/mock_pluggable_consensus.go
+++ b/kernel/consensus/mock/mock_pluggable_consensus.go
@@ -134,7 +134,7 @@ func (m *FakeMeta) GetTipBlockid() []byte {
 }
 
 func GetGenesisConsensusConf() []byte {
-	return []byte("{\"name\":\"fake\",\"config\":\"\"}")
+	return []byte("{\"name\":\"fake\",\"config\":\"{}\"}")
 }
 
 type FakeLedger struct {
@@ -390,6 +390,10 @@ type FakeRegistry struct {
 
 func (r *FakeRegistry) RegisterKernMethod(contract, method string, handler contract.KernMethod) {
 	r.M[method] = handler
+}
+
+func (r *FakeRegistry) UnregisterKernMethod(ctract, method string) {
+	return
 }
 
 func (r *FakeRegistry) GetKernMethod(contract, method string) (contract.KernMethod, error) {

--- a/kernel/consensus/pluggable_consensus.go
+++ b/kernel/consensus/pluggable_consensus.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/xuperchain/xupercore/kernel/common/xcontext"
@@ -40,6 +41,9 @@ var (
 	BuildConsensusError   = errors.New("Build consensus Error")
 	ConsensusNotRegister  = errors.New("Consensus hasn't been register. Please use consensus.Register({NAME},{FUNCTION_POINTER}) to register in consensusMap")
 	ContractMngErr        = errors.New("Contract manager is empty.")
+
+	ErrInvalidConfig  = errors.New("config should be an empty JSON when rolling back an old one, or try an upper version")
+	ErrInvalidVersion = errors.New("version should be an upper one when upgrading a new one, or try an empty config JSON when you need rollback")
 )
 
 // PluggableConsensus 实现了consensus_interface接口
@@ -191,23 +195,13 @@ func (pc *PluggableConsensus) proposalArgsUnmarshal(ctxArgs map[string][]byte) (
 
 // updateConsensus 共识升级，更新原有共识列表，向PluggableConsensus共识列表插入新共识，并暂停原共识实例
 // 该方法注册到kernel的延时调用合约中，在trigger高度时被调用，此时直接按照共识cfg新建新的共识实例
+// 若同名共识且version相同，则使用历史的配置，否则version需要递增序列
 func (pc *PluggableConsensus) updateConsensus(contractCtx contract.KContext) (*contract.Response, error) {
 	// 解析用户合约信息，包括待升级名称name、trigger高度height和待升级配置config
 	cfg, err := pc.proposalArgsUnmarshal(contractCtx.Args())
 	if err != nil {
 		return common.NewContractErrResponse(common.StatusErr, err.Error()), err
 	}
-	consensusItem, err := pc.makeConsensusItem(pc.ctx, *cfg)
-	if err != nil {
-		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::make consensu item error! Use old one.", "error", err.Error())
-		return common.NewContractErrResponse(common.StatusErr, err.Error()), err
-	}
-	transCon, ok := consensusItem.(ConsensusInterface)
-	if !ok {
-		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::consensus transfer error! Use old one.")
-		return common.NewContractErrResponse(common.StatusErr, BuildConsensusError.Error()), BuildConsensusError
-	}
-	pc.ctx.XLog.Debug("Pluggable Consensus::updateConsensus::make a new consensus item successfully during updating process.")
 
 	// 更新合约存储, 注意, 此次更新需要检查是否是初次升级情况，此时需要把genesisConf也写进map中
 	pluggableConfig, err := contractCtx.Get(contractBucket, []byte(consensusKey))
@@ -228,12 +222,26 @@ func (pc *PluggableConsensus) updateConsensus(contractCtx contract.KContext) (*c
 			return common.NewContractErrResponse(common.StatusErr, BuildConsensusError.Error()), BuildConsensusError
 		}
 	}
-	// 检查新共识，仅允许共识升级为老共识实例，不允许升级为同名新共识实例，如Tdpos升级成Xpos升级成Tdpos，两个Tdpos配置必须相同
-	if checkSameNameConsensus(c, cfg) {
-		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::same name consensus.")
+
+	// 检查新共识配置是否正确
+	if err := CheckConsensusVersion(c, cfg); err != nil {
+		pc.ctx.XLog.Error("Pluggable Consensus::updateConsensus::wrong value, pls check your proposal file.", "error", err)
+		return common.NewContractErrResponse(common.StatusErr, err.Error()), err
+	}
+
+	// 生成新的共识实例
+	consensusItem, err := pc.makeConsensusItem(pc.ctx, c[len(c)-1])
+	if err != nil {
+		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::make consensu item error! Use old one.", "error", err.Error())
+		return common.NewContractErrResponse(common.StatusErr, err.Error()), err
+	}
+	transCon, ok := consensusItem.(ConsensusInterface)
+	if !ok {
+		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::consensus transfer error! Use old one.")
 		return common.NewContractErrResponse(common.StatusErr, BuildConsensusError.Error()), BuildConsensusError
 	}
-	c[len(c)] = *cfg
+	pc.ctx.XLog.Debug("Pluggable Consensus::updateConsensus::make a new consensus item successfully during updating process.")
+
 	newBytes, err := json.Marshal(c)
 	if err != nil {
 		pc.ctx.XLog.Warn("Pluggable Consensus::updateConsensus::marshal error", "error", err)
@@ -342,7 +350,7 @@ func (pc *PluggableConsensus) GetConsensusStatus() (base.ConsensusStatus, error)
 type stepConsensus struct {
 	cons []ConsensusInterface
 	// mutex保护StepConsensus数据结构cons的读写操作
-	mutex sync.RWMutex
+	mutex sync.Mutex
 }
 
 // 向可插拔共识数组put item
@@ -356,8 +364,8 @@ func (sc *stepConsensus) put(con ConsensusInterface) error {
 // 获取最新的共识实例
 func (sc *stepConsensus) tail() ConsensusInterface {
 	//getCurrentConsensusComponent
-	sc.mutex.RLock()
-	sc.mutex.RUnlock()
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
 	if len(sc.cons) == 0 {
 		return nil
 	}
@@ -365,8 +373,8 @@ func (sc *stepConsensus) tail() ConsensusInterface {
 }
 
 func (sc *stepConsensus) len() int {
-	sc.mutex.RLock()
-	sc.mutex.RUnlock()
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
 	return len(sc.cons)
 }
 
@@ -400,34 +408,68 @@ func NewPluginConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) (base.
 	return nil, ConsensusNotRegister
 }
 
-// checkSameNameConsensus 不允许同名但配置文件不同的共识新组件
-func checkSameNameConsensus(hisMap map[int]def.ConsensusConfig, cfg *def.ConsensusConfig) bool {
-	for k, v := range hisMap {
-		if v.ConsensusName != cfg.ConsensusName {
+type configFilter struct {
+	Version string `json:"version,omitempty"`
+	index   int    `json:"-"`
+}
+
+// CheckConsensusConfig 同名配置文件检查:
+// 1. 若历史相同version，则直接返回历史cfg
+// 2. 若不存在，需要比历史最大值大
+// 3. 将合法的配置写到map中
+func CheckConsensusVersion(hisMap map[int]def.ConsensusConfig, cfg *def.ConsensusConfig) error {
+	var err error
+	var newConf configFilter
+	if cfg.ConsensusName == "pow" {
+		return nil
+	}
+	if err = json.Unmarshal([]byte(cfg.Config), &newConf); err != nil {
+		return errors.New("wrong parameter config")
+	}
+	newConfVersion, err := strconv.ParseInt(newConf.Version, 10, 64)
+	if err != nil {
+		return errors.New("wrong parameter version, version should an integer in string")
+	}
+	// 获取历史最近共识实例，初始状态下历史共识没有version字段的，需手动添加
+	var configSlice []configFilter
+	var maxVersion int64
+	for i := len(hisMap) - 1; i >= 0; i-- {
+		configItem := hisMap[i]
+		if configItem.ConsensusName != cfg.ConsensusName {
 			continue
 		}
-		if v.Config == cfg.Config {
-			if k != len(hisMap)-1 { // 允许回到历史共识实例
-				return false
+		var tmpItem configFilter
+		json.Unmarshal([]byte(configItem.Config), &tmpItem)
+		tmpItem.index = i
+		if tmpItem.Version == "" {
+			tmpItem.Version = "0"
+		}
+		if tmpItem.Version == newConf.Version {
+			dec := json.NewDecoder(strings.NewReader(cfg.Config))
+			dec.DisallowUnknownFields()
+			var checkCfg configFilter
+			err := dec.Decode(&checkCfg)
+			if err != nil {
+				return ErrInvalidConfig
 			}
-			return true // 不允许相同共识配置的升级，无意义
+			hisConfig := hisMap[i]
+			hisMap[len(hisMap)] = hisConfig
+			return nil
 		}
-		// 比对Version和bft组件是否一致即可
-		type tempStruct struct {
-			EnableBFT map[string]bool `json:"bft_config,omitempty"`
+		configSlice = append(configSlice, tmpItem)
+		v, _ := strconv.ParseInt(tmpItem.Version, 10, 64)
+		if maxVersion < v {
+			maxVersion = v
 		}
-		var newConf tempStruct
-		if err := json.Unmarshal([]byte(cfg.Config), &newConf); err != nil {
-			return true
-		}
-		var oldConf tempStruct
-		if err := json.Unmarshal([]byte(v.Config), &oldConf); err != nil {
-			return true
-		}
-		// 共识名称相同，注意: xpos和tdpos在name上都称为tdpos，但xpos的enableBFT!=nil
-		if (newConf.EnableBFT != nil && oldConf.EnableBFT != nil) || (newConf.EnableBFT == nil && oldConf.EnableBFT == nil) {
-			return true // 不允许同一共识名称的升级，如Tdpos不可以做配置升级，只能做配置回滚，如升级到xpos再升级回原来的tdpos
-		}
+		continue
 	}
-	return false
+	if len(configSlice) == 0 {
+		hisMap[len(hisMap)] = *cfg
+		return nil
+	}
+	if maxVersion < newConfVersion {
+		hisMap[len(hisMap)] = *cfg
+		return nil
+	}
+	return ErrInvalidVersion
 }

--- a/kernel/consensus/pluggable_consensus_test.go
+++ b/kernel/consensus/pluggable_consensus_test.go
@@ -229,19 +229,20 @@ func TestNewPluggableConsensus(t *testing.T) {
 }
 
 func GetNewConsensusConf() []byte {
-	return []byte("{\"name\":\"another\",\"config\":\"\"}")
+	return []byte("{\"name\":\"another\",\"config\":\"{}\"}")
 }
 
 func GetWrongConsensusConf() []byte {
-	return []byte("{\"name\":\"\",\"config\":\"\"}")
+	return []byte("{\"name\":\"\",\"config\":\"{}\"}")
 }
 
 func NewUpdateArgs() map[string][]byte {
 	a := make(map[string]interface{})
 	a["name"] = "another"
 	a["config"] = map[string]interface{}{
-		"miner":  "TeyyPLpp9L7QAcxHangtcHTu7HUZ6iydY",
-		"period": "3000",
+		"version": "1",
+		"miner":   "TeyyPLpp9L7QAcxHangtcHTu7HUZ6iydY",
+		"period":  "3000",
 	}
 	ab, _ := json.Marshal(&a)
 	r := map[string][]byte{

--- a/kernel/contract/kernel.go
+++ b/kernel/contract/kernel.go
@@ -2,6 +2,7 @@ package contract
 
 type KernRegistry interface {
 	RegisterKernMethod(contract, method string, handler KernMethod)
+	UnregisterKernMethod(ctract, method string)
 	// RegisterShortcut 用于contractName缺失的时候选择哪个合约名字和合约方法来执行对应的kernel合约
 	RegisterShortcut(oldmethod, contract, method string)
 	GetKernMethod(contract, method string) (KernMethod, error)

--- a/kernel/contract/manager/registry_impl.go
+++ b/kernel/contract/manager/registry_impl.go
@@ -38,6 +38,15 @@ func (r *registryImpl) RegisterKernMethod(ctract, method string, handler contrac
 	contractMap[method] = handler
 }
 
+func (r *registryImpl) UnregisterKernMethod(ctract, method string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if contractMap, ok := r.methods[ctract]; ok {
+		delete(contractMap, method)
+	}
+}
+
 func (r *registryImpl) RegisterShortcut(oldmethod, contract, method string) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()


### PR DESCRIPTION
* consensus: delete the RegisterKernMethod panic in registry_imp & allow consensus upgrade with a same name & add CheckConsensusVersion.

* consensus: review fix.

* consensus: rollback NewParaChainManager.

* updateConsnesus: review fix.

* updateConsensus: fix the unit-test error.

Co-authored-by: ZhengQi <qizheng09@outlook.com>